### PR TITLE
Add and configure factory bot gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,5 @@ end
 
 group :test do
   gem "rspec-rails"
-  gem "factory_bot"
+  gem "factory_bot_rails"
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faker (2.21.0)
       i18n (>= 1.8.11, < 2)
     globalid (1.0.0)
@@ -258,7 +261,7 @@ DEPENDENCIES
   debug
   devise
   devise-jwt
-  factory_bot
+  factory_bot_rails
   faker
   pg (~> 1.4, >= 1.4.4)
   prettier

--- a/spec/factories/drivers.rb
+++ b/spec/factories/drivers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :driver do
+    document { "123456789" }
+    first_name { "Han" }
+    last_name { "Solo" }
+    shipping_company { "XPTO Log" }
+  end
+end

--- a/spec/models/driver_spec.rb
+++ b/spec/models/driver_spec.rb
@@ -14,14 +14,7 @@
 require "rails_helper"
 
 RSpec.describe Driver, type: :model do
-  let(:driver) do
-    described_class.new(
-      document: "123456789",
-      first_name: "Han",
-      last_name: "Solo",
-      shipping_company: "XPTO",
-    )
-  end
+  let(:driver) { FactoryBot.build_stubbed(:driver) }
 
   describe ".creating driver" do
     context "when all fields are valid" do
@@ -33,24 +26,21 @@ RSpec.describe Driver, type: :model do
 
   context "when document is nil" do
     it "should return an error" do
-      driver =
-        described_class.new(
-          document: nil,
-          first_name: "Han",
-          shipping_company: "XPTO",
-        )
+      driver = FactoryBot.build_stubbed(:driver, document: nil)
       expect(driver).to_not be_valid
     end
   end
 
   context "when first name is nil" do
     it "should return an error" do
-      driver =
-        described_class.new(
-          document: "123456789",
-          first_name: nil,
-          shipping_company: "XPTO",
-        )
+      driver = FactoryBot.build_stubbed(:driver, first_name: nil)
+      expect(driver).to_not be_valid
+    end
+  end
+
+  context "when shipping company is nil" do
+    it "should return an error" do
+      driver = FactoryBot.build_stubbed(:driver, shipping_company: nil)
       expect(driver).to_not be_valid
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,12 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # Use color not only in STDOUT but also in pagers and files
+  config.tty = true
+
+  # Use the specified formatter
+  config.formatter = :documentation
+
   Shoulda::Matchers.configure do |config|
     config.integrate do |with|
       with.test_framework :rspec


### PR DESCRIPTION
##Context
This branch aims to add the correct Factory Bot gem to prepare objects to unit and integration tests

##Description
The `factory_bot_rails` gem was added to the project and a `Driver` has already been created using this gem as a test used in the driver unit test.