### PR TITLE
Add departure time field to shipment

### DIFF
--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -44,7 +44,7 @@ module Api
 
       def shipment_params
         params.require(:shipment).permit(:customer_id, :invoice_number, :cargo_checker, :dock, :kind, :warehouse,
-                                         :volume_quantity, :driver_id, :vehicle_id, :status)
+                                         :volume_quantity, :driver_id, :vehicle_id, :departure_time, :status)
       end
     end
   end

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -25,8 +25,13 @@ class Shipment < ApplicationRecord
   #             :warehouse,
   #             :cargo_checker,
   #             :volume_quantity,
+  #             :departure_time,
   #             :kind, presence: true
   # end
+
+  before_update(
+    if: ->(model) { model.ready? }
+  ) { |model| model.departure_time = DateTime.now.strftime('%H:%M:%S') }
 
   after_update_commit(
     if: ->(model) { model.dispatch? && model.ready? }
@@ -39,6 +44,7 @@ end
 #
 #  id              :bigint           not null, primary key
 #  cargo_checker   :string           not null
+#  departure_time  :time
 #  dock            :string           not null
 #  invoice_number  :string           not null
 #  kind            :string

--- a/app/serializers/shipment_serializer.rb
+++ b/app/serializers/shipment_serializer.rb
@@ -5,7 +5,7 @@
 #
 class ShipmentSerializer < ActiveModel::Serializer
   attributes :id, :invoice_number, :dock, :kind, :warehouse, :cargo_checker, :volume_quantity, :customer, :vehicle,
-             :driver, :created_at, :updated_at, :status
+             :driver, :created_at, :updated_at, :departure_time, :status
 end
 
 # == Schema Information
@@ -14,6 +14,7 @@ end
 #
 #  id              :bigint           not null, primary key
 #  cargo_checker   :string           not null
+#  departure_time  :string
 #  dock            :string           not null
 #  invoice_number  :string           not null
 #  kind            :string

--- a/db/migrate/20231028000047_add_departure_time_to_shipment.rb
+++ b/db/migrate/20231028000047_add_departure_time_to_shipment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDepartureTimeToShipment < ActiveRecord::Migration[7.1]
+  def up
+    add_column :shipments, :departure_time, :string
+  end
+
+  def down
+    remove_column :shipments, :departure_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_27_231631) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_28_000047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_231631) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "volume_quantity", null: false
+    t.string "departure_time"
     t.index ["customer_id"], name: "index_shipments_on_customer_id"
     t.index ["driver_id"], name: "index_shipments_on_driver_id"
     t.index ["vehicle_id"], name: "index_shipments_on_vehicle_id"

--- a/spec/factories/shipments.rb
+++ b/spec/factories/shipments.rb
@@ -22,6 +22,7 @@ end
 #
 #  id              :bigint           not null, primary key
 #  cargo_checker   :string           not null
+#  departure_time  :string
 #  dock            :string           not null
 #  invoice_number  :string           not null
 #  kind            :string

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe Shipment, type: :model do
       end
     end
 
+    context 'when the shipment is updated and the status is ready' do
+      it 'should fill in the departure time automatically' do
+        shipment = create(:shipment)
+        shipment.update!(status: 'ready')
+
+        expect(shipment).to be_valid
+        expect(shipment.departure_time).to eq(DateTime.now.strftime('%H:%M:%S'))
+      end
+    end
+
     describe '.associations' do
       it 'belongs to a driver' do
         described_class.reflect_on_association(:driver)
@@ -102,6 +112,7 @@ end
 #
 #  id              :bigint           not null, primary key
 #  cargo_checker   :string           not null
+#  departure_time  :string
 #  dock            :string           not null
 #  invoice_number  :string           not null
 #  kind            :string


### PR DESCRIPTION
##Context
This branch aims to add a new field to the Shipment model

##Description
A new field called `departure_hour` was added to record the time at which the vehicle left the dock after a delivery or dispatch of volumes accompanied by the security agent and also by the cargo checker.
This field is automatically populated via a lambda function that captures the value of `DateTime.now` function and parses it to save just the time.